### PR TITLE
Fix language selection and remove unused file

### DIFF
--- a/app/api/translate/route.ts
+++ b/app/api/translate/route.ts
@@ -19,6 +19,8 @@ export async function POST(req: Request) {
     if (req.headers.get("content-type")?.includes("multipart/form-data")) {
       const formData = await req.formData()
       const file = formData.get("file") as File
+      const formLanguage = formData.get("language")
+      language = typeof formLanguage === 'string' ? formLanguage : "english"
       
       if (!file) {
         return NextResponse.json({ error: "No file uploaded" }, { status: 400 })
@@ -68,7 +70,6 @@ export async function POST(req: Request) {
       await worker.terminate()
       
       text = ocrText
-      language = "english" // Default to English for initial upload
     } else {
       const body = await req.json()
       text = body.text

--- a/app/components/result-display.tsx
+++ b/app/components/result-display.tsx
@@ -1,2 +1,0 @@
-// Delete this entire file
-

--- a/app/components/summary.tsx
+++ b/app/components/summary.tsx
@@ -2,25 +2,33 @@
 
 import { motion, AnimatePresence } from "framer-motion"
 import ActionItem from "./action-item"
+import { LanguageSelector, type Language } from "./language-selector"
 import type { ApiResponse } from "@/app/types"
-import type { Language } from "./language-selector"
+import { useState } from "react"
 
 interface SummaryProps {
   result: ApiResponse | null
   onLanguageChange: (language: Language, ocrText: string) => Promise<void>
 }
 
-export default function Summary({ result }: SummaryProps) {
+export default function Summary({ result, onLanguageChange }: SummaryProps) {
+  const [language, setLanguage] = useState<Language>('english')
+
+  const handleSelect = async (lang: Language) => {
+    if (!result) return
+    setLanguage(lang)
+    await onLanguageChange(lang, result.ocrText!)
+  }
   return (
     <AnimatePresence mode="wait">
       {result?.success && result.summary && result.actions && (
-        <motion.div 
+        <motion.div
           className="w-full space-y-8"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
         >
-          <motion.div 
+          <motion.div
             className="text-center mb-8"
             initial={{ y: 20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
@@ -28,6 +36,7 @@ export default function Summary({ result }: SummaryProps) {
           >
             <h1 className="text-4xl font-bold text-foreground mb-4">Letter Analysis</h1>
           </motion.div>
+          <LanguageSelector selectedLanguage={language} onLanguageSelect={handleSelect} />
           
           <div className="space-y-6">
             <div className="border border-white/10 bg-white/5 rounded-xl p-6">

--- a/app/components/upload-section.tsx
+++ b/app/components/upload-section.tsx
@@ -25,13 +25,14 @@ export default function UploadSection({ onResult }: UploadSectionProps) {
       // Check if file type is supported
       const supportedTypes = ['image/jpeg', 'image/png','image/heic','image/heif', 'application/pdf']
       if (!supportedTypes.includes(file.type)) {
-        setError('Unsupported file type. Please upload a PDF, PNG, or JPEG file.')
+        setError('Unsupported file type. Please upload a PDF, PNG, JPEG, or HEIC file.')
         setIsLoading(false)
         return
       }
 
       const formData = new FormData()
       formData.append("file", file)
+      formData.append("language", language)
 
       try {
         const response = await fetch("/api/translate", {


### PR DESCRIPTION
## Summary
- send language with uploaded files
- preserve selected language on the server
- allow changing language in summary
- clarify supported file types
- remove unused `result-display` component

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684221b7e7dc8333b04b9c23555b6ba4